### PR TITLE
Separate tags from test title

### DIFF
--- a/tests/api/GET.test.ts
+++ b/tests/api/GET.test.ts
@@ -3,7 +3,7 @@ import { test } from '@playwright/test';
 
 const apiActions = new APIActions();
 
-test(`@API getUsers`, async ({ request }) => {
+test(`getUsers`, { tag: '@API'}, async ({ request }) => {
     const response = await request.get(`/api/users?per_page=1`);
     await apiActions.verifyStatusCode(response);
 

--- a/tests/api/POST.test.ts
+++ b/tests/api/POST.test.ts
@@ -3,7 +3,7 @@ import { test } from '@playwright/test';
 
 const apiActions = new APIActions();
 
-test(`@API postUsers`, async ({ request }) => {
+test(`postUsers`, { tag: '@API'}, async ({ request }) => {
 
     //* Body Response Params and Body Response Headers are stored in single text file separated by #
     const requestBody = JSON.parse((await apiActions.readValuesFromTextFile('postUsers')).split(`#`)[0]);

--- a/tests/functional/AlertsFrameWindows.test.ts
+++ b/tests/functional/AlertsFrameWindows.test.ts
@@ -1,6 +1,6 @@
 import test from '@lib/BaseTest';
 
-test(`@Smoke Verify Alerts, Frame & Windows Page`, async ({ loginPage, alertsFrameWindowsPage, webActions }) => {
+test(`Verify Alerts, Frame & Windows Page`, { tag: '@Smoke'}, async ({ loginPage, alertsFrameWindowsPage, webActions }) => {
     await loginPage.navigateToURL();
     await webActions.clickByText('Alerts, Frame & Windows'); // Click on Alerts, Frame & Windows icon
     await webActions.clickByText('Browser Windows'); // Click on Browser Windows navigation side bar

--- a/tests/functional/Elements.test.ts
+++ b/tests/functional/Elements.test.ts
@@ -1,6 +1,6 @@
 import test from '@lib/BaseTest';
 
-test(`@Smoke Verify Elements Page`, async ({ loginPage, elementsPage, webActions }) => {
+test(`Verify Elements Page`, { tag: '@Smoke'}, async ({ loginPage, elementsPage, webActions }) => {
     await loginPage.navigateToURL();
     await webActions.clickByText('Elements'); // Click on Elements Icon identified via text selector
     await webActions.clickByText('Text Box'); //Click on TextBox Navigation Sidebar identified via text selector

--- a/tests/functional/Interactions.test.ts
+++ b/tests/functional/Interactions.test.ts
@@ -1,6 +1,6 @@
 import test from '@lib/BaseTest';
 
-test(`@Smoke Verify Interactions Page`, async ({ loginPage, interactionsPage, webActions }) => {
+test(`Verify Interactions Page`, { tag: '@Smoke'}, async ({ loginPage, interactionsPage, webActions }) => {
     await loginPage.navigateToURL();
     await webActions.clickByText('Interactions'); // Click on Interactions Icon identified via text selector
     await webActions.clickByText('Droppable');

--- a/tests/functional/Login.test.ts
+++ b/tests/functional/Login.test.ts
@@ -2,7 +2,7 @@ import test from '@lib/BaseTest';
 
 // We can use Steps like in Cucmber format as shown below
 
-test(`@Smoke Verify Book Store Login`, async ({ loginPage, webActions }) => {
+test(`Verify Book Store Login`, { tag: '@Smoke'}, async ({ loginPage, webActions }) => {
     await test.step(`Navigate to Application`, async () => {
         await loginPage.navigateToURL();
     });

--- a/tests/functional/PdfToText.test.ts
+++ b/tests/functional/PdfToText.test.ts
@@ -1,7 +1,7 @@
 import test from '@lib/BaseTest';
 import { expect } from '@playwright/test';
 
-test(`@Smoke Verify the text contents of PDF file.`, async ({ webActions }) => {
+test(`Verify the text contents of PDF file.`, { tag: '@Smoke'}, async ({ webActions }) => {
     const extractedText = await webActions.getPDFText("./utils/functional/sample.pdf");
     const status = extractedText.includes("A Simple PDF File")
     expect(status).toBeTruthy();

--- a/tests/functional/Widgets.test.ts
+++ b/tests/functional/Widgets.test.ts
@@ -1,6 +1,6 @@
 import test from '@lib/BaseTest';
 
-test(`@Smoke Verify Widgets Page`, async ({ loginPage, widgetsPage, webActions }) => {
+test(`Verify Widgets Page`, { tag: '@Smoke'}, async ({ loginPage, widgetsPage, webActions }) => {
     await loginPage.navigateToURL();
     await webActions.clickByText('Widgets'); // Click on Widgets Icon identified via text selector
     await webActions.clickByText('Auto Complete');


### PR DESCRIPTION
Playwright version 1.42 offers a new syntax to seperate tags from title, this will make the test looks little neat 

https://playwright.dev/docs/release-notes#version-142